### PR TITLE
Fix for trivialInput so that instances produced are providers of IRichInput

### DIFF
--- a/machinist/_fsm.py
+++ b/machinist/_fsm.py
@@ -5,7 +5,7 @@
 Implementation details for machinist's public interface.
 """
 
-from zope.interface import Attribute, Interface, implementer, provider
+from zope.interface import Attribute, Interface, implementer
 from zope.interface.exceptions import DoesNotImplement
 
 from eliot import Field, ActionType, Logger
@@ -489,7 +489,7 @@ def trivialInput(symbol):
     @return: A new type object usable as a rich input for the given symbol.
     @rtype: L{type}
     """
-    return provider(IRichInput)(implementer(IRichInput))(type(
+    return implementer(IRichInput)(type(
             symbol.name.title(), (FancyStrMixin, object), {
                 "symbol": _symbol(symbol),
                 }))

--- a/machinist/test/test_fsm.py
+++ b/machinist/test/test_fsm.py
@@ -398,7 +398,7 @@ class TrivialInputTests(TestCase):
         self.assertTrue(verifyClass(IRichInput, trivialInput(Input.apple)))
 
 
-    def test_interface_on_instance(self):
+    def test_interfaceOnInstance(self):
         """
         The an instance of the object returned by L{trivialInput} provides
         L{IRichInput}.

--- a/machinist/topfiles/14.bugfix
+++ b/machinist/topfiles/14.bugfix
@@ -1,0 +1,1 @@
+trivialInput used to produce a type which provided IRichInput, but an instance of said type would not provide IRichInput.  This has been fixed and now trivialInput produces a type that implements IRichInput, whose instances provide IRichInput.


### PR DESCRIPTION
Have trivialInput produce an implementer of IRichInput, whose instances will be providers of IRichInput.

Fixes #14

I don't know if #7 means to deprecate or delete `trivialInput` entirely, but this way there are smaller changes.
